### PR TITLE
docs: 접근성(IME·보조 기술), 웹 IME 명세 요약 문서 추가

### DIFF
--- a/src/components/DocsSidebar.astro
+++ b/src/components/DocsSidebar.astro
@@ -125,6 +125,8 @@ const sidebarGroups: SidebarGroup[] = [
       { label: 'KeyboardEvent.isComposing', href: '/docs/reference/is-composing' },
       { label: 'IME·한글 구현 코드 예시', href: '/docs/reference/code-examples' },
       { label: 'IME 구현 상세', href: '/docs/reference/ime-implementation-details' },
+      { label: '웹 IME 명세 요약', href: '/docs/reference/web-ime-specs' },
+      { label: '접근성(IME·보조 기술)', href: '/docs/reference/ime-accessibility' },
       { label: '유니코드 기본', href: '/docs/reference/unicode-basics' },
       { label: '이모지', href: '/docs/reference/emoji' },
       { label: 'macOS 한글 자소 분리', href: '/docs/reference/mac-hangul-decomposition' },

--- a/src/content/docs/reference/ime-accessibility.md
+++ b/src/content/docs/reference/ime-accessibility.md
@@ -1,0 +1,46 @@
+---
+title: 접근성(IME·보조 기술)
+description: IME 조합 중 preedit의 접근성 트리 노출, 스크린 리더·보조 기술과의 관계, 에디터 권장 사항
+---
+
+IME로 **조합 중인 문자열(preedit)** 과 **확정된 문자열(commit)** 이 **스크린 리더·보조 기술**에 어떻게 전달되는지, 그리고 에디터가 **접근성을 고려해** 조합 구간을 어떻게 다루면 좋은지 정리한다. 명세·플랫폼별 동작은 환경에 따라 다르므로, 가능한 범위만 구체적으로 기술한다.
+
+---
+
+## 1. 조합 중(preedit)의 접근성 트리 노출
+
+### 1.1 브라우저·OS 동작
+
+- **접근성 트리**(Accessibility Tree)는 보조 기술(스크린 리더 등)이 **요소의 역할·이름·값·상태**를 읽을 때 사용한다.
+- **input**·**textarea** 또는 **contenteditable** 요소에 **조합 중인 텍스트**가 있을 때, 브라우저와 OS가 그 내용을 **접근성 트리에 어떻게 반영하는지**는 **구현에 따라 다르다**.
+- 일부 환경에서는 **preedit이 "값"의 일부**로 노출되어 스크린 리더가 **조합 중 문자열을 읽을 수 있다**. 일부 환경에서는 **조합이 끝난(commit된) 값만** 노출되고, 조합 중에는 **이전 값 또는 빈 값**만 읽힐 수 있다.
+- **실시간 영역(Live Region)** 으로 preedit 구간을 마크하면, 변경 시 **알림**을 받을 수 있으나, IME 조합 구간을 **live region으로만** 처리하는 방식은 명세에서 권장하는 패턴이 아니며, 브라우저가 **자동으로** preedit을 접근성 트리에 넣는 방식과 충돌할 수 있다.
+
+### 1.2 에디터가 할 수 있는 것
+
+- **조합 구간**을 **문서 모델에 반영하지 않고** "화면에만" 표시하는 것은 IME 동작과 맞다. 이때 **해당 구간이 DOM에서 어떻게 표현되는지**(예: 별도 span, `aria-hidden` 여부)에 따라 **스크린 리더가 읽는 내용**이 달라질 수 있다.
+- **일반적인 권장**: **compositionstart ~ compositionend** 구간을 **하나의 편집 단위**로 두고, **포커스·선택 영역**이 조합 문자열 **밖으로 나가지 않게** 하는 것이 **입력 경험**과 **접근성** 모두에 유리하다. 조합 중에 커서가 조합 문자열을 쪼개면, 스크린 리더가 **불완전한 조각**을 읽을 수 있다.
+- **aria 속성**: `role="textbox"` 또는 `role="combobox"` 등에 **aria-describedby**·**aria-label**로 힌트를 줄 수 있으나, **preedit 자체**를 aria로 노출하는 공식 패턴은 Input Events·ARIA 명세에 정의되어 있지 않다. **실무에서는** 브라우저가 제공하는 **기본 접근성 트리**를 신뢰하고, **에디터는 조합 구간을 하나의 단위로 유지**하는 데 집중하는 것이 안전하다.
+
+---
+
+## 2. commit 후 접근성
+
+- **compositionend**로 **commit**이 끝나면, 해당 문자열은 **문서(또는 input value)** 에 반영된다. 이 시점부터는 **일반 텍스트**와 동일하게 접근성 트리의 **값**으로 노출된다.
+- **스크린 리더**는 보통 **값 변경**을 **알림**으로 읽어 준다. **commit 한 번**이 **한 번의 변경**으로 인식되므로, **조합 중에는 문서에 반영하지 않고** **commit 시점에만 반영**하는 구현이 **"한 번에 한 단위"**로 읽히는 데 유리하다.
+
+---
+
+## 3. 키보드·포커스
+
+- **조합 중**에 **Tab**으로 포커스를 옮기면, 일부 환경에서는 **compositionend**가 발생하지 않을 수 있다(Safari blur 이슈 등). [트러블슈팅](/docs/reference/troubleshooting)의 **blur 시 조합 상태 정리**를 적용하면, **포커스가 나갈 때** preedit을 정리해 **접근성 트리와 실제 문서**가 어긋나지 않게 할 수 있다.
+- **단축키** 처리 시 **isComposing** 또는 **keyCode 229**를 확인해 **조합 중에는** 단축키를 먹지 않고 IME에 넘기면, **스크린 리더 사용자**가 IME 조합을 끝낸 뒤 단축키를 쓸 수 있다.
+
+---
+
+## 4. 참고
+
+- [에디터 IME 구현 가이드](/docs/editor/implementation-notes) — 조합 구간·commit 처리.
+- [트러블슈팅](/docs/reference/troubleshooting) — blur 시 composition 정리, isComposing 처리.
+- [W3C Input Events Level 2](https://www.w3.org/TR/input-events-2/) — inputType, getTargetRanges.
+- ARIA: [ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/), [Live Regions](https://www.w3.org/WAI/ARIA/apg/practices/notifications/).

--- a/src/content/docs/reference/web-ime-specs.md
+++ b/src/content/docs/reference/web-ime-specs.md
@@ -1,0 +1,80 @@
+---
+title: 웹 IME 명세 요약
+description: Input Events Level 2·UI Events에서 composition·beforeinput·inputType의 요구사항과 선택 사항
+---
+
+웹에서 IME 조합은 **CompositionEvent**(UI Events)와 **InputEvent**/**beforeinput**(Input Events Level 2)로 다룬다. 이 문서는 **명세에서 요구하는 것**과 **구현에 맡기는 것(선택·재량)**을 정리해, 에디터 구현 시 **어디까지 보장되고 어디서 브라우저 차이가 나는지** 참고할 수 있게 한다.
+
+---
+
+## 1. CompositionEvent (UI Events)
+
+### 1.1 정의
+
+- **CompositionEvent**는 **UI Events** 명세에서 정의한다. **compositionstart**, **compositionupdate**, **compositionend** 세 가지가 있다.
+- **사용자가 IME를 통해 간접적으로 텍스트를 입력할 때** 발생한다(MDN·명세). **data** 속성에 **조합으로 대체될 기존 문자열**(compositionstart), **현재 조합 중 문자열**(compositionupdate), **확정된 문자열 또는 빈 문자열**(compositionend)이 들어 있다.
+
+### 1.2 명세가 말하는 것
+
+- **compositionstart**: 조합 세션이 **시작될 때** 발생. **data**는 조합으로 **대체될** 기존 선택 영역의 텍스트(없으면 빈 문자열).
+- **compositionupdate**: 조합 **중 내용이 바뀔 때** 발생. **data**는 **현재 조합 중인 문자열**(preedit).
+- **compositionend**: 조합이 **끝날 때** 발생. **data**는 **commit**이면 확정 문자열, **취소**면 빈 문자열.
+
+이 **의미**는 명세가 정하고, **발생 시점·횟수**(예: compositionupdate가 몇 번 오는지)는 **IME·OS·브라우저**에 따라 다르다.
+
+### 1.3 명세가 강제하지 않는 것
+
+- **compositionstart 없이 compositionend만** 오는 경우를 명세가 **금지하지 않는다**. 레거시 IME나 상태 꼬임에서 발생할 수 있으므로, 에디터는 **compositionend만** 와도 **data**가 있으면 commit으로 처리하는 것이 안전하다.
+- **compositionupdate가 0번**인 경우(compositionstart 직후 compositionend만 오는 경우)도 **가능**하다. [composition 시나리오별 처리 규칙](/docs/reference/composition-edge-cases) 참고.
+
+---
+
+## 2. Input Events Level 2: beforeinput / inputType
+
+### 2.1 beforeinput
+
+- **beforeinput**은 **편집 가능한 요소의 내용이 바뀌기 직전**에 발생한다. **InputEvent.inputType**으로 **삽입·삭제·서식** 등을 구분한다.
+- **명세**: IME 조합으로 텍스트가 삽입될 때는 **insertCompositionText** 등의 inputType이 정의되어 있다. **조합 종료(commit)** 시 **insertText** 또는 **insertCompositionText** 등이 올 수 있다.
+
+### 2.2 명세가 강제하지 않는 것
+
+- **beforeinput이 발생하지 않을 수 있다**. MDN 등에는 "IME, 자동 완성, 비밀번호 관리자 등"에서 **beforeinput이 생략**될 수 있다고 적혀 있다.
+- **beforeinput이 non-cancelable**일 수 있다. 즉, **preventDefault()**가 동작하지 않는 환경이 있다.
+- **insertCompositionText** 대신 **insertText**만 오는 구현이 **허용**되는지 여부는 명세 문구에 따라 다르나, **실제로** iOS Safari 등에서는 **insertCompositionText** 없이 **insertText**만 오므로, 에디터는 **composition 이벤트**와 **insertText** 둘 다 처리해야 한다.
+
+### 2.3 getTargetRanges()
+
+- **beforeinput**에서 **getTargetRanges()**로 **영향받는 범위**를 얻을 수 있다. **insertReplacementText**, **deleteWordBackward** 등에서 **교체·삭제할 구간**을 지정할 때 쓰인다.
+- **명세**: 지원이 **선택**일 수 있고, **모든 브라우저·환경**에서 사용 가능하지 않다. 없으면 **커서·선택**으로 범위를 직접 계산해야 한다. [inputType 상세](/docs/reference/inputtype) §4.2 참고.
+
+---
+
+## 3. 이벤트 순서
+
+- **명세**는 **compositionstart → compositionupdate(들) → compositionend** 순서를 전제한다. **beforeinput**·**input**이 그 **전후**에 어떻게 끼어드는지는 **Input Events Level 2** 문구에 세부가 나와 있으나, **정확한 순서**가 **강제**되지는 않는다.
+- **실제 브라우저**에서는 **compositionend 직후 input**이 같은 내용으로 **한 번 더** 오는 경우(Safari 등), **Enter** 시 **compositionend가 조기** 발생하는 경우(Firefox 버그) 등이 있다. [composition 시나리오별 처리 규칙](/docs/reference/composition-edge-cases), [브라우저·플랫폼별 IME 동작 차이](/docs/reference/browser-platform-quirks) 참고.
+- **결론**: **구현은 composition 3종을 우선** 처리하고, **composition이 없을 때** **inputType·insertText**로 처리하는 구조가 **명세와 실제 동작 모두**에 맞다.
+
+---
+
+## 4. 에디터 구현 시 대응 원칙
+
+| 명세/동작 | 에디터 대응 |
+|-----------|-------------|
+| compositionstart ~ compositionend | 조합 구간을 preedit으로만 표시, **compositionend.data**만 문서에 반영 |
+| composition 없이 insertText | `!isComposing && inputType === 'insertText'` 시 **data**를 commit |
+| compositionend.data가 빈 문자열 | 취소로 간주, preedit만 제거 |
+| compositionend.data가 긴 문자열 | 한 글자 가정 금지, 전체를 하나의 undo 단위로 commit |
+| beforeinput 없음 | **input** 이벤트로 동일 처리 |
+| getTargetRanges() 없음 | 커서·선택으로 범위 직접 계산 |
+| blur 시 compositionend 없음 | **blur** 리스너에서 **isComposing**이면 조합 상태 강제 정리 |
+
+---
+
+## 5. 참고 문서
+
+- [글자 조합](/docs/guide/composition) — composition 이벤트 흐름, beforeinput/input과의 관계.
+- [inputType 상세](/docs/reference/inputtype) — inputType 목록, 환경별 차이, 명세의 한계.
+- [composition 시나리오별 처리 규칙](/docs/reference/composition-edge-cases) — 예외 시나리오별 처리.
+- [W3C UI Events](https://w3c.github.io/uievents/) — CompositionEvent.
+- [W3C Input Events Level 2](https://www.w3.org/TR/input-events-2/) — beforeinput, inputType, getTargetRanges.


### PR DESCRIPTION
## Summary
- 접근성(IME·보조 기술): preedit 접근성 트리, 스크린 리더·에디터 권장, commit·키보드/포커스
- 웹 IME 명세 요약: CompositionEvent·Input Events Level 2, 이벤트 순서, 에디터 대응 원칙
- 사이드바 참고 그룹에 항목 반영

Closes #9

Made with [Cursor](https://cursor.com)